### PR TITLE
Fix version tag on image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,20 +11,16 @@ DOCKER_NAME := meteogroup/docker-terragrunt
 # Version tag taken from environment, file, or calculated date
 VERSION_FILE := version.txt
 ifdef VERSION
-  $(shell echo "version=$(VERSION)" > $(VERSION_FILE))
-  $(info using version $(VERSION) from parameter input or environment)
+$(shell echo "version=$(VERSION)" > $(VERSION_FILE))
+$(info using version $(VERSION) from parameter input or environment)
 else ifneq ("$(wildcard $(VERSION_FILE))","")
-  VERSION=$(shell awk -F'=' '/version/{print $$2}' $(VERSION_FILE))
-  $(info using version $(VERSION) from file $(VERSION_FILE))
+VERSION := $(shell awk -F'=' '/version/{print $$2}' $(VERSION_FILE))
+$(info using version $(VERSION) from file $(VERSION_FILE))
 else
-  VERSION=$(shell date -u +"%Y-%m-%dT%H-%M-%SZ")
-  $(shell echo "version=$(VERSION)" > $(VERSION_FILE))
-  $(info using version $(VERSION) which is self-calculated)
+VERSION := $(shell date -u +"%Y-%m-%dT%H-%M-%SZ")
+$(shell echo "version=$(VERSION)" > $(VERSION_FILE))
+$(info using version $(VERSION) which is self-calculated)
 endif
-
-clean:
-	@docker rmi $(DOCKER_NAME):latest || true
-	@docker rmi $(DOCKER_NAME):$(VERSION) || true
 
 docker-create:
 	docker build \
@@ -43,4 +39,4 @@ else
 	docker push $(DOCKER_NAME):$(CURRENT_BRANCH)-$(VERSION)
 endif
 
-build-deploy: clean docker-create docker-push
+build-deploy: docker-create docker-push

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ else
 endif
 
 clean:
-	@rm -f $(VERSION_FILE)
 	@docker rmi $(DOCKER_NAME):latest || true
 	@docker rmi $(DOCKER_NAME):$(VERSION) || true
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ $(shell echo "version=$(VERSION)" > $(VERSION_FILE))
 $(info using version $(VERSION) which is self-calculated)
 endif
 
+clean:
+	@rm -f $(VERSION_FILE)
+
 docker-create:
 	docker build \
 	  --build-arg TF_VERSION=$(TF_VERSION) \
@@ -39,4 +42,4 @@ else
 	docker push $(DOCKER_NAME):$(CURRENT_BRANCH)-$(VERSION)
 endif
 
-build-deploy: docker-create docker-push
+build-deploy: clean docker-create docker-push

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 Dockerfile is based on two images made by [cytopia](https://github.com/cytopia).
 
 Those two images are [docker-terragrunt](https://github.com/cytopia/docker-terragrunt/tree/1bc1a2c6de42c6d19f7e91f64f30256c24fd386f) and [docker-terragrunt-fmt](https://github.com/cytopia/docker-terragrunt-fmt/tree/3f8964bea0db043a05d4a8d622f94a07f109b5a7).
-Their content can be found in `originals` folder.
 
 Some changes have been applied to add more software to the image - list below.
 


### PR DESCRIPTION
For some reason during Bamboo run we have:
```
Successfully tagged meteogroup/docker-terragrunt:2019-11-26T09-42-05Z
tag meteogroup/docker-terragrunt:2019-11-26T09-43-13Z meteogroup/docker-terragrunt:latest
```
So just before being pushed docker expects different version tag.
This change should assure version is read from the `version.txt` even if makefile is run second time.